### PR TITLE
fix: compatibility with Typst 0.14.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - fix-ci
+  pull_request:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.repository == 'TJ-CSCCG/tongji-undergrad-thesis-typst'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download fonts from fonts branch
+        run: |
+          git fetch origin fonts
+          git checkout FETCH_HEAD -- fonts
+
+      - name: Setup Typst
+        uses: typst-community/setup-typst@v4
+
+      - name: Compile thesis
+        run: |
+          typst compile init-files/main.typ thesis.pdf --root . --font-path ./fonts
+
+      - name: Upload PDF
+        uses: actions/upload-artifact@v5
+        with:
+          name: thesis-pdf
+          path: thesis.pdf
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,52 @@
-# General
-.vscode
-.idea
-_things
-desktop.ini
-.DS_Store
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+ 
+# OS generated files #
+######################
+.DS_Store?
+ehthumbs.db
+Icon?
+Thumbs.db
+*.DS_Store
+ 
+# Xcode
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+*.xcuserstate
+project.xcworkspace/
+xcuserdata/
+ 
+ 
+# IDE
+*.idea
+*.iml
+ 
+# Generated files
+/web-app/WEB-INF
+build/
+*.[oa]
+*.pyc
+ 
+# Other source repository archive directories (protects when importing)
+.hg
+.svn
+CVS
+ 
+# automatic backup files
+*~.nib
+*.swp
+*~
+*(Autosaved).rtfd/
+Backup[ ]of[ ]*.pages/
+Backup[ ]of[ ]*.key/
+Backup[ ]of[ ]*.numbers/
 
 # Typst
 *.pdf
-*test*
+fonts/*
+!fonts/README.md

--- a/paddling-tongji-thesis/elements.typ
+++ b/paddling-tongji-thesis/elements.typ
@@ -1,6 +1,6 @@
 #import "@preview/i-figured:0.2.2"
-#import "@preview/tablex:0.0.6": cellx, tablex, gridx, hlinex, vlinex, colspanx, rowspanx
-#import "@preview/algo:0.3.3": algo, i, d, comment, code
+#import "@preview/tablex:0.0.9": cellx, tablex, gridx, hlinex, vlinex, colspanx, rowspanx
+#import "@preview/algo:0.3.5": algo, i, d, comment, code
 
 #import "utils.typ": *
 
@@ -108,47 +108,45 @@
   // outline(title: "目录", depth: 3)
   heading(title, numbering: none, outlined: false)
   set par(first-line-indent: 0pt, leading: 0.9em)
-  locate(
-    it => {
-      let elements = query(heading.where(outlined: true), it)
+  context {
+    let elements = query(heading.where(outlined: true))
 
-      for el in elements {
-        // Skip headings that are too deep
-        if depth != none and el.level > depth { continue }
+    for el in elements {
+      // Skip headings that are too deep
+      if depth != none and el.level > depth { continue }
 
-        let el_number = if el.numbering != none {
-          numbering(el.numbering, ..counter(heading).at(el.location()))
-          h(0.5em)
-        }
+      let el_number = if el.numbering != none {
+        numbering(el.numbering, ..counter(heading).at(el.location()))
+        h(0.5em)
+      }
 
-        let line = {
-          if indent {
-            let indent-width = if el.level == 1 {
-              0pt
-            } else if el.level == 2 {
-              1em
-            } else if el.level == 3 {
-              4em
-            } else {
-              0pt
-            }
-
-            h(indent-width)
+      let line = {
+        if indent {
+          let indent-width = if el.level == 1 {
+            0pt
+          } else if el.level == 2 {
+            1em
+          } else if el.level == 3 {
+            4em
+          } else {
+            0pt
           }
 
-          link(el.location(), el_number)
-          link(el.location(), el.body)
-          box(width: 1fr, h(0.25em) + box(width: 1fr, repeat[·#h(1pt)]) + h(0.25em))
-          link(el.location(),str(counter(page).at(el.location()).first()))
-
-          linebreak()
+          h(indent-width)
         }
 
-        // link(el.location(), line)
-        line
+        link(el.location(), el_number)
+        link(el.location(), el.body)
+        box(width: 1fr, h(0.25em) + box(width: 1fr, repeat[·#h(1pt)]) + h(0.25em))
+        link(el.location(),str(counter(page).at(el.location()).first()))
+
+        linebreak()
       }
-    },
-  )
+
+      // link(el.location(), line)
+      line
+    }
+  }
 }
 
 #let heavyrulewidth = .08em

--- a/paddling-tongji-thesis/tongjithesis.typ
+++ b/paddling-tongji-thesis/tongjithesis.typ
@@ -19,7 +19,7 @@
   pagebreak()
 
   set par(justify: true, first-line-indent: 2em, leading: 0.9em)
-  show par: set block(spacing: 0.9em)
+  set par(spacing: 0.9em)
   set math.equation(numbering: none) // not implemented yet: (1.1)
   show strong: it => text(font: font-family.hei, weight: "bold", it.body)
   show emph: it => text(font: font-family.kai, style: "italic", it.body)
@@ -38,57 +38,55 @@
     "abcdefghijklmnopqrstuvwxyz".at(nums.pos().at(-1) - 1) + ". "
   })
 
-  show heading: it => locate(
-    loc => {
-      if it.level == 1 {
-        set align(center)
-        set text(font: font-family.hei, size: font-size.at("4"), weight: "bold")
-        if it.numbering != none {
-          numbering(it.numbering, ..counter(heading).at(loc))
-          h(1em)
-          it.body
-        } else {
-          it
-        }
-        v(1.5em)
-      } else if it.level == 2 {
-        set text(font: font-family.hei, size: font-size.at("5"), weight: "bold")
-        v(0.5em)
-        if it.numbering != none {
-          h(-2em)
-          numbering(it.numbering, ..counter(heading).at(loc))
-          h(1em)
-          it.body
-        } else {
-          it
-        }
-        v(1em)
-      } else if it.level == 3 {
-        set text(font: font-family.hei, size: font-size.at("5"), weight: "bold")
-        v(0.5em)
-        if it.numbering != none {
-          numbering(it.numbering, ..counter(heading).at(loc))
-          h(1em)
-          it.body
-        } else {
-          it
-        }
-        v(1em)
-      } else if it.level == 4 {
-        set text(font: font-family.hei, size: font-size.at("5"), weight: "bold")
-        v(-0.5em)
-        grid(columns: (2em, 1fr), [], it)
-        v(0.5em)
-      } else if it.level == 5 {
-        set text(font: font-family.hei, size: font-size.at("5"), weight: "bold")
-        v(-0.5em)
-        grid(columns: (2em, 1fr), [], it)
-        v(0.5em)
+  show heading: it => context {
+    if it.level == 1 {
+      set align(center)
+      set text(font: font-family.hei, size: font-size.at("4"), weight: "bold")
+      if it.numbering != none {
+        numbering(it.numbering, ..counter(heading).get())
+        h(1em)
+        it.body
       } else {
         it
       }
-    },
-  ) + empty-par()
+      v(1.5em)
+    } else if it.level == 2 {
+      set text(font: font-family.hei, size: font-size.at("5"), weight: "bold")
+      v(0.5em)
+      if it.numbering != none {
+        h(-2em)
+        numbering(it.numbering, ..counter(heading).get())
+        h(1em)
+        it.body
+      } else {
+        it
+      }
+      v(1em)
+    } else if it.level == 3 {
+      set text(font: font-family.hei, size: font-size.at("5"), weight: "bold")
+      v(0.5em)
+      if it.numbering != none {
+        numbering(it.numbering, ..counter(heading).get())
+        h(1em)
+        it.body
+      } else {
+        it
+      }
+      v(1em)
+    } else if it.level == 4 {
+      set text(font: font-family.hei, size: font-size.at("5"), weight: "bold")
+      v(-0.5em)
+      grid(columns: (2em, 1fr), [], it)
+      v(0.5em)
+    } else if it.level == 5 {
+      set text(font: font-family.hei, size: font-size.at("5"), weight: "bold")
+      v(-0.5em)
+      grid(columns: (2em, 1fr), [], it)
+      v(0.5em)
+    } else {
+      it
+    }
+  } + empty-par()
 
   show list: it => it + empty-par()
   show enum: it => it + empty-par()
@@ -112,11 +110,11 @@
       v(-0.5em)
       line(length: 100%, stroke: 1.8pt)
       draw-binding()
-    }, header-ascent: 20%, footer: locate(loc => {
+    }, header-ascent: 20%, footer: context {
       set align(center)
       set text(font: font-family.song, size: font-size.at("-4"))
-      numbering("I", counter(page).at(loc).first())
-    }),
+      numbering("I", counter(page).get().first())
+    },
   )
   counter(page).update(1)
 
@@ -133,20 +131,20 @@
   make-outline()
   pagebreak()
 
-  set page(footer: locate(loc => {
+  set page(footer: context {
     line(stroke: 1.8pt, length: 100%)
     set align(right)
     set text(font: font-family.song, size: font-size.at("-4"))
     v(-0.6em)
     [
       共#h(1em)
-      #counter(page).final(loc).at(0)#h(1em)
+      #counter(page).final().at(0)#h(1em)
       页#h(1em)
       第#h(1em)
       #counter(page).display()
       #h(1em)页
     ]
-  }))
+  })
   counter(page).update(1)
 
   doc


### PR DESCRIPTION
## 对该 PR 的总结

- 更新 `algo` 包从 0.3.3 到 0.3.5
- 更新 `tablex` 包从 0.0.6 到 0.0.9  
- 将已弃用的 `locate()` 函数替换为 `context`
- 更新 counter API 调用以适配新版本

## 该 PR 的成功合入是否需要关闭一些 Issue？

Close #9 

## 该 PR 的其他信息

本 PR 修复了模板与 Typst 0.14.0 的兼容性问题。之前用户在使用最新版本 Typst 编译时会遇到 `type state has no method display` 和 `only element functions can be used as selectors` 的错误。修改后的代码已在 Typst 0.14.0 上成功编译测试。