### PR TITLE
Fix CI workflow to support forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,15 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'TJ-CSCCG/tongji-undergrad-thesis-typst'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Download fonts from fonts branch
+      - name: Download fonts from upstream
         run: |
-          git fetch origin fonts
+          git fetch https://github.com/TJ-CSCCG/tongji-undergrad-thesis-typst.git fonts
           git checkout FETCH_HEAD -- fonts
 
       - name: Setup Typst


### PR DESCRIPTION
## 对该 PR 的总结

- 修改 CI workflow，从上游 TJ-CSCCG 仓库获取字体文件，使 CI 能在 fork 的仓库中正常运行
- 移除了仓库检查条件 (`if: github.repository == ...`)

### 该 PR 的成功合入是否需要关闭一些 Issue？

N/A

### 该 PR 的功能展示

CI workflow 现在会：
1. 从 `https://github.com/TJ-CSCCG/tongji-undergrad-thesis-typst.git` 的 `fonts` 分支获取字体
2. 在任何 fork 的仓库中都能正常编译

### 该 PR 的其他信息

这是对之前 PR 的补充修复，确保 CI 在 fork 仓库中也能工作。