### PR TITLE
Fix page numbering for main text

### DIFF
--- a/paddling-tongji-thesis/tongjithesis.typ
+++ b/paddling-tongji-thesis/tongjithesis.typ
@@ -131,7 +131,7 @@
   make-outline()
   pagebreak()
 
-  set page(footer: context {
+  set page(numbering: "1", footer: context {
     line(stroke: 1.8pt, length: 100%)
     set align(right)
     set text(font: font-family.song, size: font-size.at("-4"))


### PR DESCRIPTION
## 对该 PR 的总结

- 修复主体内容页码显示问题：将主体内容的页码格式从罗马数字（I, II, III...）改为阿拉伯数字（1, 2, 3...）
- 在 `set page` 中添加 `numbering: "1"` 参数

### 该 PR 的成功合入是否需要关闭一些 Issue？

N/A

### 该 PR 的功能展示

修复前：主体内容页脚显示 "共 16 页 第 II 页"
修复后：主体内容页脚显示 "共 16 页 第 2 页"

### 该 PR 的其他信息

问题原因：在设置主体内容的页脚时，只更新了 footer 但没有更新 `numbering` 格式，导致 `counter(page).display()` 继续使用前面设置的罗马数字格式。